### PR TITLE
Fixing broken hex.pm documentation link

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule ConfexParameterStore.MixProject do
 
   defp docs() do
     [
-      main: @name,
+      main: "Confex.Adapters.ParameterStore",
       source_ref: "v#{@version}",
       source_url: @url,
       extras: [


### PR DESCRIPTION
Fixing the broken documentation link on hex docs
Broken:
https://hexdocs.pm/confex_parameter_store/Confex%20Parameter%20Store%20Adapter.html

Fixed: https://hexdocs.pm/confex_parameter_store/Confex.Adapters.ParameterStore.html